### PR TITLE
fix(calendar): fix Issue with events now showing in calendar for negative time zone offsets

### DIFF
--- a/lib/helpers/date_time.dart
+++ b/lib/helpers/date_time.dart
@@ -41,16 +41,16 @@ String? getFormattedProductionDate(String? prodDate) {
   return DateFormat('dd. MMM y').format(parsedDateTime);
 }
 
-/// Get current UTC offset in the format 'hh:mm'
+/// Get current UTC offset in the format '(+/-)hh:mm'
 String getUtcOffset() {
   final timeZoneOffset = DateTime.now().timeZoneOffset;
-  final hours = timeZoneOffset.inHours.toString().padLeft(2, '0');
-  final minutes = (timeZoneOffset.inMinutes % 60).toString().padLeft(2, '0');
-  return '$hours:$minutes';
+  final hours = timeZoneOffset.inHours.abs().toString().padLeft(2, '0');
+  final minutes = (timeZoneOffset.inMinutes.abs() % 60).toString().padLeft(2, '0');
+  return '${timeZoneOffset.isNegative ? '-' : '+'}$hours:$minutes';
 }
 
 /// Get date in ISO8601 format with UTC offset
 String getFormattedDateTime(DateTime date) {
   final localDateTime = DateFormat('yyyy-MM-ddTHH:mm:ss').format(date);
-  return '$localDateTime+${getUtcOffset()}';
+  return '$localDateTime${getUtcOffset()}';
 }


### PR DESCRIPTION
<!--
Thanks for creating a PR!
To make it easier for reviewers and everyone else to understand your PR, please add some relevant content to the headings below.
Feel free to delete sections that you don't think are relevant. -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
<!-- (For BCC employees): Include link to notion if relevant, e.g.: https://www.notion.so/bccmedia/something -->
Fix Issue with events not showing in calendar for negative time zone offsets.
The date sent to graphql was getting constructed as '\<date\>**+-7**:00' instead of '\<date\>**-07**:00' when the time zone offset is negative.
