### PR TITLE
fix(poster-grid-section): issue with poster grid section displayed as default grid section

### DIFF
--- a/lib/components/sections/thumbnail_grid/item_section_thumbnail_grid.dart
+++ b/lib/components/sections/thumbnail_grid/item_section_thumbnail_grid.dart
@@ -38,6 +38,7 @@ class ItemSectionThumbnailGrid extends StatelessWidget {
       margin: const EdgeInsets.symmetric(horizontal: kIsWeb ? 80 : 16),
       child: ThumbnailGrid(
         gridSize: data.gridSize,
+        aspectRatio: aspectRatio,
         sectionItems: data.items.items,
         showSecondaryTitle: showSecondaryTitle,
       ),


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
<!-- (For BCC employees): Include link to notion if relevant, e.g.: https://www.notion.so/bccmedia/something -->
Fix issue with poster grid section displayed as default grid section
