### PR TITLE
feat(parent-gate): move parent gate check to profile

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:bccm_player/bccm_player.dart';
+import 'package:brunstadtv_app/components/parents/parental_gate.dart';
 import 'package:brunstadtv_app/graphql/client.dart';
 import 'package:brunstadtv_app/graphql/queries/me.graphql.dart';
 import 'package:brunstadtv_app/providers/auth_state/auth_state.dart';
@@ -167,7 +168,10 @@ class HomeScreenState extends ConsumerState<HomeScreen> with PageMixin implement
                     alignment: Alignment.centerLeft,
                     child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
-                        onTap: () {
+                        onTap: () async {
+                          if ((FlavorConfig.current.flavor == Flavor.kids && !await checkParentalGate(context)) || !context.mounted) {
+                            return;
+                          }
                           context.router.pushNamed('/profile');
                         },
                         child: Padding(

--- a/lib/screens/profile/profile.dart
+++ b/lib/screens/profile/profile.dart
@@ -1,6 +1,4 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:brunstadtv_app/components/parents/parental_gate.dart';
-import 'package:brunstadtv_app/helpers/ui/btv_buttons.dart';
 import 'package:brunstadtv_app/helpers/ui/svg_icons.dart';
 import 'package:brunstadtv_app/providers/auth_state/auth_state.dart';
 import 'package:brunstadtv_app/providers/feature_flags.dart';
@@ -209,22 +207,14 @@ class _ProfileState extends ConsumerState<ProfileScreen> {
                             if (FlavorConfig.current.flavor == Flavor.kids)
                               OptionButton(
                                 optionName: S.of(context).makeDonation,
-                                onPressed: () async {
-                                  if (!await checkParentalGate(context)) {
-                                    return;
-                                  }
+                                onPressed: () {
                                   final locale = ref.read(settingsProvider).appLanguage.languageCode;
                                   launchUrlString('https://biblekids.io/${locale}/support-our-work', mode: LaunchMode.externalApplication);
                                 },
                               ),
                             OptionButton(
                               optionName: S.of(context).about,
-                              onPressed: () async {
-                                if (!await checkParentalGate(context) || !context.mounted) {
-                                  return;
-                                }
-                                context.router.push(const AboutScreenRoute());
-                              },
+                              onPressed: () => context.router.push(const AboutScreenRoute()),
                             ),
                           ],
                         ),
@@ -235,12 +225,7 @@ class _ProfileState extends ConsumerState<ProfileScreen> {
                               buttons: [
                                 OptionButton(
                                   optionName: S.of(context).privacyPolicy,
-                                  onPressed: () async {
-                                    if (!await checkParentalGate(context) || !context.mounted) {
-                                      return;
-                                    }
-                                    context.router.push(const PrivacyPolicyScreenRoute());
-                                  },
+                                  onPressed: () => context.router.push(const PrivacyPolicyScreenRoute()),
                                 ),
                               ],
                             );


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
<!-- (For BCC employees): Include link to notion if relevant, e.g.: https://www.notion.so/bccmedia/something -->
Move parent gate up a level and check before profile page is opened instead of checking for individual buttons in profile.
