### PR TITLE
change default auth method for documentation on developer.bcc.no to bcc-login

### DIFF
--- a/.github/workflows/build-and-deploy-documentations.yml
+++ b/.github/workflows/build-and-deploy-documentations.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           title: BrunstadTV App
           description: BrunstadTV app documentation
+          authentication: 'portal'


### PR DESCRIPTION
## About the changes
change default auth method for documentation on developer.bcc.no to bcc-login

