### PR TITLE
feat(analytics): add ref to meta enrichment

### DIFF
--- a/kids/lib/helpers/analytics_meta.dart
+++ b/kids/lib/helpers/analytics_meta.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:kids/router/router.gr.dart';
 
 class KidsAnalyticsMetaEnricher extends AnalyticsMetaEnricher {
-  KidsAnalyticsMetaEnricher(super.ref);
+  KidsAnalyticsMetaEnricher([super.ref]);
 
   @override
   String? getScreenName(Route route) {

--- a/kids/lib/helpers/analytics_meta.dart
+++ b/kids/lib/helpers/analytics_meta.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:kids/router/router.gr.dart';
 
 class KidsAnalyticsMetaEnricher extends AnalyticsMetaEnricher {
+  KidsAnalyticsMetaEnricher(super.ref);
+
   @override
   String? getScreenName(Route route) {
     // Use pageRouteArgs.pageCode if we ever add a dynamic page route.

--- a/kids/lib/main.dart
+++ b/kids/lib/main.dart
@@ -96,7 +96,7 @@ Future<void> $main({
 
     final appRouter = AppRouter(navigatorKey: globalNavigatorKey);
     final coreOverrides = await BccmCore().setupCoreOverrides(
-      analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => KidsAnalyticsMetaEnricher(ref)),
+      analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => KidsAnalyticsMetaEnricher()),
       specialRoutesHandlerProviderOverride: specialRoutesHandlerProvider.overrideWith((ref) => KidsSpecialRoutesHandler(ref)),
       rootRouterProviderOverride: rootRouterProvider.overrideWithValue(appRouter),
       commonSettingsProviderOverride: commonSettingsProviderOverride,

--- a/kids/lib/main.dart
+++ b/kids/lib/main.dart
@@ -96,7 +96,7 @@ Future<void> $main({
 
     final appRouter = AppRouter(navigatorKey: globalNavigatorKey);
     final coreOverrides = await BccmCore().setupCoreOverrides(
-      analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => KidsAnalyticsMetaEnricher()),
+      analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => KidsAnalyticsMetaEnricher(ref)),
       specialRoutesHandlerProviderOverride: specialRoutesHandlerProvider.overrideWith((ref) => KidsSpecialRoutesHandler(ref)),
       rootRouterProviderOverride: rootRouterProvider.overrideWithValue(appRouter),
       commonSettingsProviderOverride: commonSettingsProviderOverride,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,7 +63,7 @@ Future<void> $main({
 
       final appRouter = AppRouter(navigatorKey: globalNavigatorKey);
       final coreOverrides = await BccmCore().setupCoreOverrides(
-        analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => BccmAnalyticsMetaEnricher()),
+        analyticsMetaEnricherProviderOverride: analyticsMetaEnricherProvider.overrideWith((ref) => BccmAnalyticsMetaEnricher(ref)),
         specialRoutesHandlerProviderOverride: specialRoutesHandlerProvider.overrideWith((ref) => BccmSpecialRoutesHandler(ref)),
         rootRouterProviderOverride: rootRouterProvider.overrideWithValue(appRouter),
         commonSettingsProviderOverride: commonSettingsProviderOverride,

--- a/lib/providers/analytics.dart
+++ b/lib/providers/analytics.dart
@@ -55,7 +55,8 @@ class BccmAnalyticsMetaEnricher extends AnalyticsMetaEnricher {
     }
 
     final onboardingRouteArgs = route.settings.arguments.asOrNull<OnboardingScreenRouteArgs>();
-    if (onboardingRouteArgs != null) {
+    final ref = this.ref;
+    if (onboardingRouteArgs != null && ref != null) {
       extraProperties['meta']['hasEverLoggedIn'] = ref.read(sharedPreferencesProvider).getBool(PrefKeys.hasEverLoggedIn);
     }
 

--- a/lib/providers/analytics.dart
+++ b/lib/providers/analytics.dart
@@ -20,6 +20,8 @@ final analyticsProviderOverride = analyticsProvider.overrideWith((ref) {
 });
 
 class BccmAnalyticsMetaEnricher extends AnalyticsMetaEnricher {
+  BccmAnalyticsMetaEnricher(super.ref);
+
   @override
   String? getScreenName(Route<dynamic> route) {
     final pageRouteArgs = route.settings.arguments.asOrNull<PageScreenRouteArgs>();
@@ -50,6 +52,11 @@ class BccmAnalyticsMetaEnricher extends AnalyticsMetaEnricher {
     final routeData = route.data;
     if (routeData != null && routeData.meta.containsKey(RouteMetaConstants.settingsName)) {
       extraProperties['meta']['settings'] = routeData.meta[RouteMetaConstants.settingsName];
+    }
+
+    final onboardingRouteArgs = route.settings.arguments.asOrNull<OnboardingScreenRouteArgs>();
+    if (onboardingRouteArgs != null) {
+      extraProperties['meta']['hasEverLoggedIn'] = ref.read(sharedPreferencesProvider).getBool(PrefKeys.hasEverLoggedIn);
     }
 
     return extraProperties;


### PR DESCRIPTION
We want to add some metadata to the onboarding screen tracking to identify how many of the users have ever logged in.
Changes in bccm-flutter: https://github.com/bcc-code/bccm-flutter/pull/2