### PR TITLE
feat: replace maestro cloud with devicecloud

### DIFF
--- a/.maestro/ci.sh
+++ b/.maestro/ci.sh
@@ -6,6 +6,11 @@ set -x
 export MAESTRO_VERSION=1.39.7; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 
+#install devicecloud cli
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+nvm install 22
+npm install -g @devicecloud.dev/dcd
+
 #run maestro e2e tests
 envsubst < flows/scripts/.env.js.template > flows/scripts/.env.js
 flutter doctor -v
@@ -13,5 +18,5 @@ flutter doctor -v
 # build the app for the simulator
 make ios-build
 
-maestro cloud --apiKey $MAESTRO_API_KEY -e PLATFORM=ios --exclude-tags=no-cloud ../build/ios/iphonesimulator/Runner.app flows/ || exit 1
+dcd cloud --apiKey $MAESTRO_API_KEY -e PLATFORM=ios --exclude-tags=no-cloud ../build/ios/iphonesimulator/Runner.app flows/ || exit 1
 exit 0


### PR DESCRIPTION
Replace Maestro Cloud with devicecloud, which is a cheaper ($0.1/test run) alternative. 
This is a test to see if we can replace Robin, which is the "new Maestro Cloud" ($250/month)