### PR TITLE
fix: make update dialog work again

### DIFF
--- a/lib/app_root_inner.dart
+++ b/lib/app_root_inner.dart
@@ -15,10 +15,13 @@ class AppRootInner extends HookConsumerWidget {
       if (next == null) return;
       final packageInfo = ref.read(packageInfoProvider);
       if (isOldAppVersion(current: packageInfo.version, minimum: next.application.clientVersion)) {
-        showDialog(
-          context: context,
-          builder: (context) => const AppUpdateDialog(),
-        );
+        final navigatorContext = globalNavigatorKey.currentState?.overlay?.context;
+        if (navigatorContext != null) {
+          showDialog(
+            context: navigatorContext,
+            builder: (context) => const AppUpdateDialog(),
+          );
+        }
       }
     });
     return child;


### PR DESCRIPTION
The `showDialog` function needed access to the Navigator in the context passed in as an argument, but that was not available in the context that was passed in.

The fix was to get the context with the Navigator