### PR TITLE
fix: stop mini player when opening shorts page

### DIFF
--- a/lib/components/shorts/short_scroll_view.dart
+++ b/lib/components/shorts/short_scroll_view.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:auto_route/auto_route.dart';
 import 'package:bccm_core/bccm_core.dart';
 import 'package:bccm_core/platform.dart';
+import 'package:bccm_player/bccm_player.dart';
 import 'package:brunstadtv_app/components/shorts/short_view.dart';
 import 'package:brunstadtv_app/components/status/error_adaptive.dart';
 import 'package:brunstadtv_app/helpers/constants.dart';
@@ -141,6 +142,7 @@ class ShortScrollView extends HookConsumerWidget {
     useEffect(() {
       isRouteActiveRef.value = isRouteActive;
       if (isRouteActive) {
+        BccmPlayerController.primary.pause();
         debugPrint('SHRT: shorts view became active, playing');
         final player = shortControllers[currentIndex.value % playerCount].player;
         if (player.value.isInitialized) {

--- a/lib/screens/tabs/tabs_root.dart
+++ b/lib/screens/tabs/tabs_root.dart
@@ -175,6 +175,9 @@ class _TabsRootScreenState extends ConsumerState<TabsRootScreen> with AutoRouteA
         return true;
       }
     }
+    if (currentRouteMatch.name == ShortsScreenRoute.name) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
The mini player is now paused and hidden when navigating to shorts screen